### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v1
+    - name: Setup Node.js for use with actions
+      uses: actions/setup-node@v1.1.0
+      with:
+        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
+        version: lts
+    - name: Install dependencies from Yarn
+      run: yarn install --frozen-lockfile
+    - name: Build Typescript sources
+      run: yarn workspace @mavenomics/metapackage run build
+    - name: Build extras
+      run: yarn workspaces run build:ci
+    - name: Generate Bundles
+      run: |
+        yarn workspace @mavenomics/mql-worker run bundle:ci
+        yarn workspace @mavenomics/viewer run bundle:ci
+        yarn workspace @mavenomics/standalone run bundle:ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v1.1.0
       with:
-        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
-        version: lts
+        version: 10.x
     - name: Install dependencies from Yarn
       run: yarn install --frozen-lockfile
     - name: Build Typescript sources

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,25 @@
+
+name: Test
+
+on: [push]
+
+jobs:
+  build:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v1
+    - name: Setup Node.js for use with actions
+      uses: actions/setup-node@v1.1.0
+      with:
+        version: 10.x
+    - name: Install dependencies from Yarn
+      run: yarn install --frozen-lockfile
+    - name: Build Typescript sources
+      run: yarn workspace @mavenomics/metapackage run build
+    - name: Lint sources
+      run: yarn run lint
+    - name: Run unit tests
+      run: yarn run test --silent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,9 @@ jobs:
       run: yarn workspace @mavenomics/metapackage run build
     - name: Lint sources
       run: yarn run lint
+    - name: Build and bundle extras
+      run: |
+        yarn workspaces run build:ci
+        yarn workspace @mavenomics/mql-worker run bundle:ci
     - name: Run unit tests
       run: yarn run test --silent


### PR DESCRIPTION
This makes the project independent of the CI server used on the upstream project, and allows this project to continue with no recurring development costs aside from my time and my caffeine.